### PR TITLE
[PAN-1979/-1980] Secondary node validator nonce updates and transfer submission task

### DIFF
--- a/pantos/validatornode/database/access.py
+++ b/pantos/validatornode/database/access.py
@@ -536,7 +536,7 @@ def update_reversal_transfer(
                 destination_blockchain_id=destination_blockchain.value,
                 recipient_address=recipient_address,
                 destination_token_contract_id=destination_token_contract_id,
-                updated=datetime.datetime.utcnow())
+                updated=datetime.datetime.now(datetime.timezone.utc))
         session.execute(statement)
 
 
@@ -564,7 +564,7 @@ def update_transfer_confirmed_destination_transaction(
             destination_transfer_id=destination_transfer_id,
             destination_transaction_id=destination_transaction_id,
             destination_block_number=destination_block_number,
-            updated=datetime.datetime.utcnow())
+            updated=datetime.datetime.now(datetime.timezone.utc))
     with get_session_maker().begin() as session:
         session.execute(statement)
 
@@ -608,7 +608,7 @@ def update_transfer_submitted_destination_transaction(
                 destination_hub_contract_id=destination_hub_contract_id,
                 destination_forwarder_contract_id=  # noqa: E251
                 destination_forwarder_contract_id,
-                updated=datetime.datetime.utcnow())
+                updated=datetime.datetime.now(datetime.timezone.utc))
         session.execute(update_statement)
 
 
@@ -730,8 +730,8 @@ def update_transfer_source_transaction(internal_transfer_id: int,
                                                   source_transfer_id)
         transfer.source_block_number = typing.cast(sqlalchemy.Column,
                                                    source_block_number)
-        transfer.updated = typing.cast(sqlalchemy.Column,
-                                       datetime.datetime.utcnow())
+        transfer.updated = typing.cast(
+            sqlalchemy.Column, datetime.datetime.now(datetime.timezone.utc))
 
 
 def update_transfer_status(internal_transfer_id: int,
@@ -750,8 +750,8 @@ def update_transfer_status(internal_transfer_id: int,
         transfer = session.get(Transfer, internal_transfer_id)
         assert transfer is not None
         transfer.status_id = typing.cast(sqlalchemy.Column, status.value)
-        transfer.updated = typing.cast(sqlalchemy.Column,
-                                       datetime.datetime.utcnow())
+        transfer.updated = typing.cast(
+            sqlalchemy.Column, datetime.datetime.now(datetime.timezone.utc))
 
 
 def update_transfer_task_id(internal_transfer_id: int,
@@ -770,8 +770,28 @@ def update_transfer_task_id(internal_transfer_id: int,
         transfer = session.get(Transfer, internal_transfer_id)
         assert transfer is not None
         transfer.task_id = typing.cast(sqlalchemy.Column, str(task_id))
-        transfer.updated = typing.cast(sqlalchemy.Column,
-                                       datetime.datetime.utcnow())
+        transfer.updated = typing.cast(
+            sqlalchemy.Column, datetime.datetime.now(datetime.timezone.utc))
+
+
+def update_transfer_validator_nonce(internal_transfer_id: int,
+                                    validator_nonce: int) -> None:
+    """Update a transfer's validator nonce.
+
+    Parameters
+    ----------
+    internal_transfer_id : int
+        The unique internal ID of the transfer.
+    validator_nonce : int
+        The new validator nonce assigned to the transfer.
+
+    """
+    statement = sqlalchemy.update(Transfer).where(
+        Transfer.id == internal_transfer_id).values(
+            validator_nonce=validator_nonce,
+            updated=datetime.datetime.now(datetime.timezone.utc))
+    with get_session_maker().begin() as session:
+        session.execute(statement)
 
 
 def _read_id(session: sqlalchemy.orm.Session, model: typing.Type[B],

--- a/tests/business/transfers/test_submit_transfer_offchain.py
+++ b/tests/business/transfers/test_submit_transfer_offchain.py
@@ -1,0 +1,59 @@
+import unittest.mock
+
+import celery.exceptions  # type: ignore
+import pytest
+
+from pantos.validatornode.business.transfers import TransferInteractorError
+from pantos.validatornode.business.transfers import \
+    submit_transfer_offchain_task
+
+
+@pytest.mark.parametrize('submission_completed', [True, False])
+@unittest.mock.patch('pantos.validatornode.business.transfers.config', {
+    'tasks': {
+        'submit_transfer_offchain': {
+            'retry_interval_in_seconds': 120
+        }
+    }
+})
+@unittest.mock.patch(
+    'pantos.validatornode.business.transfers.TransferInteractor')
+def test_submit_transfer_offchain_task_correct(mock_transfer_interactor,
+                                               submission_completed,
+                                               internal_transfer_id,
+                                               cross_chain_transfer,
+                                               cross_chain_transfer_dict):
+    mock_transfer_interactor().submit_transfer_offchain.return_value = \
+        submission_completed
+    if submission_completed:
+        submit_transfer_offchain_task(internal_transfer_id,
+                                      cross_chain_transfer_dict)
+    else:
+        with pytest.raises(celery.exceptions.Retry):
+            submit_transfer_offchain_task(internal_transfer_id,
+                                          cross_chain_transfer_dict)
+    mock_transfer_interactor().submit_transfer_offchain.\
+        assert_called_once_with(internal_transfer_id, cross_chain_transfer)
+
+
+@unittest.mock.patch(
+    'pantos.validatornode.business.transfers.config', {
+        'tasks': {
+            'submit_transfer_offchain': {
+                'retry_interval_after_error_in_seconds': 300
+            }
+        }
+    })
+@unittest.mock.patch(
+    'pantos.validatornode.business.transfers.TransferInteractor')
+def test_submit_transfer_offchain_task_error(mock_transfer_interactor,
+                                             internal_transfer_id,
+                                             cross_chain_transfer,
+                                             cross_chain_transfer_dict):
+    mock_transfer_interactor().submit_transfer_offchain.side_effect = \
+        TransferInteractorError('')
+    with pytest.raises(TransferInteractorError):
+        submit_transfer_offchain_task(internal_transfer_id,
+                                      cross_chain_transfer_dict)
+    mock_transfer_interactor().submit_transfer_offchain.\
+        assert_called_once_with(internal_transfer_id, cross_chain_transfer)

--- a/tests/database/sqlite/access/test_create_transfer.py
+++ b/tests/database/sqlite/access/test_create_transfer.py
@@ -127,5 +127,6 @@ def _check_created_transfer(created_transfer, input_transfer,
             TransferStatus.SOURCE_TRANSACTION_DETECTED.value)
     assert (created_transfer.status.name ==
             TransferStatus.SOURCE_TRANSACTION_DETECTED.name)
-    assert created_transfer.created < datetime.datetime.utcnow()
+    assert created_transfer.created < datetime.datetime.now(
+        datetime.timezone.utc).replace(tzinfo=None)
     assert created_transfer.updated is None

--- a/tests/database/sqlite/access/test_create_validator_node_signature.py
+++ b/tests/database/sqlite/access/test_create_validator_node_signature.py
@@ -36,4 +36,5 @@ def test_create_validator_node_signature_correct(
     if validator_node_existent:
         assert validator_node_signature.validator_node_id == validator_node.id
     assert validator_node_signature.signature == signature
-    assert validator_node_signature.created < datetime.datetime.utcnow()
+    assert validator_node_signature.created < datetime.datetime.now(
+        datetime.timezone.utc).replace(tzinfo=None)

--- a/tests/database/sqlite/access/test_update_transfer_validator_nonce.py
+++ b/tests/database/sqlite/access/test_update_transfer_validator_nonce.py
@@ -1,0 +1,35 @@
+import datetime
+import unittest.mock
+
+import sqlalchemy.orm
+
+from pantos.validatornode.database.access import \
+    update_transfer_validator_nonce
+
+
+@unittest.mock.patch('pantos.validatornode.database.access.get_session_maker')
+def test_update_transfer_validator_nonce_correct(
+        mock_get_session_maker, initialized_database_session_maker, transfer,
+        other_validator_nonce):
+    assert transfer.validator_nonce != other_validator_nonce
+    mock_get_session_maker.return_value = initialized_database_session_maker
+    initialized_database_session = initialized_database_session_maker()
+    initialized_database_session.add(transfer)
+    initialized_database_session.commit()
+    transfer_dict = {
+        key: value
+        for key, value in vars(transfer).items() if key != 'validator_nonce'
+        and not isinstance(value, sqlalchemy.orm.state.InstanceState)
+    }
+    date_time_before_update = datetime.datetime.now(datetime.timezone.utc)
+
+    update_transfer_validator_nonce(transfer.id, other_validator_nonce)
+
+    date_time_after_update = datetime.datetime.now(datetime.timezone.utc)
+    initialized_database_session.refresh(transfer)
+    assert transfer.validator_nonce == other_validator_nonce
+    assert transfer.updated > date_time_before_update.replace(tzinfo=None)
+    assert transfer.updated < date_time_after_update.replace(tzinfo=None)
+    updated_transfer_dict = vars(transfer)
+    for key, value in transfer_dict.items():
+        assert updated_transfer_dict[key] == value


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Test(s)
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds for secondary validator nodes
- the possibility to update the validator nonce for a cross-chain transfer and
- the Celery task for submitting a cross-chain transfer signature to the primary node.

Apart from that, the deprecated `datetime.datetime.utcnow` function is replaced in the database access functions.