### PR TITLE
[PAN-2082] Return transferTo signature as string

### DIFF
--- a/pantos/validatornode/blockchains/ethereum.py
+++ b/pantos/validatornode/blockchains/ethereum.py
@@ -330,7 +330,7 @@ class EthereumClient(BlockchainClient):
                 request.destination_forwarder_address, pan_token_address)
             signed_message = web3.Account.sign_message(
                 message, private_key=self.__private_key)
-            return signed_message.signature
+            return signed_message.signature.to_0x_hex()
         except Exception:
             raise self._create_error('unable to sign a transferTo message',
                                      request=request)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Test(s)
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The signature of a `transferTo` message is currently returned as a `HexBytes` object, but needs to be a string.