### PR TITLE
fix: download artifacts requires now regex

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,8 @@ jobs:
           egress-policy: audit
       - uses: actions/download-artifact@v4
         with:
-          name: build
+          merge-multiple: true
+          pattern: build-*
           path: dist
 
       # We need to upload some artifacts, any, so that the download action works
@@ -187,7 +188,8 @@ jobs:
           egress-policy: audit
       - uses: actions/download-artifact@v4
         with:
-          name: build
+          merge-multiple: true
+          pattern: build-*
           path: dist
 
       - name: List directory


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Test(s)
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Download Artifacts action fixed a _**bug**_ that caused not fully specified regexes to be considered as regexes. Apparently we were successfully using this bug on our pipelines, but now the fix broke them 🤦‍♀️ 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?