### PR TITLE
fix: remove arm64 architecture from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        architecture: ["amd64", "arm64"]
+        architecture: ["amd64"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64']
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
@@ -327,7 +327,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['amd64', 'arm64']
+        arch: ['amd64']
     env:
       PANTOS_VALIDATOR_NODE: ${{ github.workspace }}/validatornode
     steps:

--- a/.github/workflows/docker-vulnerabilities.yaml
+++ b/.github/workflows/docker-vulnerabilities.yaml
@@ -14,7 +14,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            arch: [amd64, arm64]
+            arch: [amd64]
         permissions: 
           contents: read
           # for sarif


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Test(s)
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the arm64 option from the list of architectures to be tested. The only reason to temporarily remove this architecture from our CI is the speed on the GitHub runners when using this architecture. This is a temporal removal, and we will enable it when native runners are available.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?