### PR TITLE
fix: add missing configuration for second vuln step

### DIFF
--- a/.github/workflows/docker-vulnerabilities.yaml
+++ b/.github/workflows/docker-vulnerabilities.yaml
@@ -93,6 +93,7 @@ jobs:
                 format: 'sarif'
                 output: 'trivy-worker-results.sarif'
                 severity: 'CRITICAL,HIGH'
+                trivy-config: .github/workflows/config/trivy.yaml
             
             - name: Upload Trivy scan results for worker to GitHub Security tab
               uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Test(s)
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix missing configuration file for second trivy analysis on DockerVulnerabilities step.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?