### PR TITLE
fix: force poetry under 2.0.0 as freeze plugin is not supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN ARCH=$(uname -m) && \
     bash miniconda.sh -b && \
     rm -f miniconda.sh
 
-RUN python3 -m pip install poetry
+RUN python3 -m pip install 'poetry<2.0.0'
 
 WORKDIR /app
 

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ export DH_VIRTUALENV_INSTALL_ROOT=/opt/pantos
 export POETRY_VIRTUALENVS_CREATE=false
 PYTHON_VERSION = 3.12.4
 SNAKE=debian/$(PACKAGE)$(DH_VIRTUALENV_INSTALL_ROOT)/$(PACKAGE)/bin/python3
-EXTRA_REQUIREMENTS=--upgrade-pip --preinstall "setuptools>=38" --preinstall "poetry" --preinstall "dh-poetry"
+EXTRA_REQUIREMENTS=--upgrade-pip --preinstall "setuptools>=38" --preinstall "poetry<2.0.0" --preinstall "dh-poetry"
 DH_VENV_ARGS=--builtin-venv --python=$(SNAKE) $(EXTRA_REQUIREMENTS) \
             --extra-pip-arg=--progress-bar=on \
 			--pip-tool dh-poetry


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Poetry 2.0.0 has been released but the freeze plugin has not been updated so we're sticking with 1.x for the moment.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?